### PR TITLE
Origin dev/opinfo ref

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -7,7 +7,7 @@ from torch.testing import \
     (FileCheck, floating_and_complex_types_and)
 from torch.testing._internal.common_utils import \
     (TestCase, is_iterable_of_tensors, run_tests, IS_SANDCASTLE, clone_input_helper, make_tensor,
-     gradcheck, gradgradcheck)
+     gradcheck, gradgradcheck, suppress_warnings)
 from torch.testing._internal.common_methods_invocations import \
     (op_db, method_tests)
 from torch.testing._internal.common_device_type import \

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -9,7 +9,7 @@ from torch.testing._internal.common_utils import \
     (TestCase, is_iterable_of_tensors, run_tests, IS_SANDCASTLE, clone_input_helper, make_tensor,
      gradcheck, gradgradcheck, suppress_warnings)
 from torch.testing._internal.common_methods_invocations import \
-    (op_db, method_tests)
+    (op_db, method_tests, test_funcs)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, ops, onlyCPU, onlyOnCPUAndCUDA, skipCUDAIfRocm, OpDTypes)
 from torch.testing._internal.common_jit import JitCommonTestCase, check_against_reference
@@ -21,7 +21,7 @@ from torch.testing._internal.jit_utils import disable_autodiff_subgraph_inlining
 
 # Get names of all the operators which have entry in `method_tests` (legacy testing infra)
 method_tested_operators = set(map(lambda test_details: test_details[0], method_tests()))
-only_testing_ops = ['roll']
+only_testing_ops = list(filter(lambda op: op.ref is not _NOTHING, test_funcs))
 
 # Tests that apply to all operators
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -21,6 +21,7 @@ from torch.testing._internal.jit_utils import disable_autodiff_subgraph_inlining
 
 # Get names of all the operators which have entry in `method_tests` (legacy testing infra)
 method_tested_operators = set(map(lambda test_details: test_details[0], method_tests()))
+only_testing_ops = ['roll']
 
 # Tests that apply to all operators
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -9,7 +9,7 @@ from torch.testing._internal.common_utils import \
     (TestCase, is_iterable_of_tensors, run_tests, IS_SANDCASTLE, clone_input_helper, make_tensor,
      gradcheck, gradgradcheck, suppress_warnings)
 from torch.testing._internal.common_methods_invocations import \
-    (op_db, method_tests, test_funcs)
+    (op_db, method_tests, test_funcs, _NOTHING)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, ops, onlyCPU, onlyOnCPUAndCUDA, skipCUDAIfRocm, OpDTypes)
 from torch.testing._internal.common_jit import JitCommonTestCase, check_against_reference
@@ -90,6 +90,8 @@ class TestOpInfo(TestCase):
                 self.assertEqualHelper(actual, expected, msg, dtype=dtype, equal_nan=equal_nan, exact_dtype=exact_dtype)
 
         for t in tensors:
+            print('t: ', t)
+            t = t.input
             torch_kwargs, numpy_kwargs = op.sample_kwargs(t.device, dtype, t)
             if dtype is torch.bfloat16:
                 a = t.cpu().to(torch.float32).numpy()

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6508,6 +6508,7 @@ op_db: List[OpInfo] = [
 
 # Common operator groupings
 unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo)]
+test_funcs = [op for op in op_db if isinstance(op, OpInfo)]
 spectral_funcs = [op for op in op_db if isinstance(op, SpectralFuncInfo)]
 sparse_unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo) and op.supports_sparse is True]
 shape_funcs = [op for op in op_db if isinstance(op, ShapeFuncInfo)]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -193,6 +193,7 @@ class OpInfo(object):
                  name,  # the string name of the function
                  *,
                  ref=None,  # Just a reference
+                 sample_kwargs=lambda device, dtype, input: ({}, {}),
                  op=None,  # the function variant of the operation, populated as torch.<name> if None
                  dtypes=floating_types(),  # dtypes this function is expected to work with
                  dtypesIfCPU=None,  # dtypes this function is expected to work with on CPU
@@ -243,6 +244,7 @@ class OpInfo(object):
 
         self.name = name
         self.ref = ref
+        self.sample_kwargs = sample_kwargs
         self.aten_name = aten_name if aten_name is not None else name
         self.variant_test_name = variant_test_name
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -192,6 +192,7 @@ class OpInfo(object):
     def __init__(self,
                  name,  # the string name of the function
                  *,
+                 ref=None,  # Just a reference
                  op=None,  # the function variant of the operation, populated as torch.<name> if None
                  dtypes=floating_types(),  # dtypes this function is expected to work with
                  dtypesIfCPU=None,  # dtypes this function is expected to work with on CPU
@@ -241,6 +242,7 @@ class OpInfo(object):
             assert isinstance(dtype_list, (_dispatch_dtypes, type(None)))
 
         self.name = name
+        self.ref = ref
         self.aten_name = aten_name if aten_name is not None else name
         self.variant_test_name = variant_test_name
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5375,6 +5375,8 @@ op_db: List[OpInfo] = [
            assert_autodiffed=True,
            sample_inputs_func=sample_inputs_permute),
     OpInfo('pow',
+           ref=np.power,
+           variant_test_name='test_check_pow',
            dtypes=all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool),
            # Due to AVX2 curently not being fully supported for Float16, log_vml_cpu can't be enabled
            # for Float16, causing this test to fail. pow's autograd for Float16 is thus currently
@@ -5515,6 +5517,8 @@ op_db: List[OpInfo] = [
                                 device_type='cpu', dtypes=[torch.complex64])
                    )),
     OpInfo('split',
+           # ref=np.split,
+           # variant_test_name='test_check_split',
            dtypes=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),
            sample_inputs_func=partial(sample_inputs_split, list_args=False),
            supports_out=False,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5431,6 +5431,7 @@ op_db: List[OpInfo] = [
                        SkipInfo('TestUnaryUfuncs', 'test_out_arg_all_dtypes'),
                    )),
     OpInfo('roll',
+           ref=np.roll,
            dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.half),
            supports_out=False,
            sample_inputs_func=sample_inputs_roll),


### PR DESCRIPTION
This PR will ideally add `ref` argument to `OpInfo` base class. The idea is to add reference checks for all the ops _eligible_. For more discussion, please check `#58294`

* [x] Migrate (but not removing yet) and modify helper functions from `UnaryUfuncOpInfo` class to `OpInfo` base class.
* [ ] Test the reference checks for multiple ops. (also decide a list of different and eligible ops for this)
* [ ] Handle possible edge cases (for example: `uint64` isn't implemented in PyTorch but is there in NumPy, and this needs to be handled -- more on this later)
* [ ] Create a sample PR for a single (of all different categories?) on adding reference functions to the eligible ops.

`cc: @mruberry @pmeier @kshiteej12345`