### PR TITLE
Use macro based impl; Add support for more unary ufuncs (sparse CSR)

### DIFF
--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -164,17 +164,38 @@ bool is_square_or_vec(int64_t dim_i, int64_t dim_j, int64_t dim_k) {
   return (dim_i == dim_k  && dim_k == dim_j) || (dim_i == dim_j && dim_k == 1);
 }
 
-Tensor& sin_sparse_csr_out(const Tensor& self, Tensor& result) {
-  return unary_op_out(&at::sin_outf, self, result);
-}
+#define CREATE_UNARY_FUNC(func) \
+  Tensor& func##_##sparse_csr_out(const Tensor& self, Tensor& result) { \
+    return unary_op_out(&at::func##_##outf, self, result);              \
+  }                                                                     \
+  Tensor func##_##sparse_csr(const Tensor& self) {                      \
+    return get_result_tensor_for_unary_op(&at::func, self);             \
+  }                                                                     \
+  Tensor& func##_##sparse_csr_(Tensor& self) {                          \
+    return func##_##sparse_csr_out(self, self);                         \
+  }
 
-Tensor sin_sparse_csr(const Tensor& self) {
-  return get_result_tensor_for_unary_op(&at::sin, self);
-}
-
-Tensor& sin_sparse_csr_(Tensor& self) {
-  return sin_sparse_csr_out(self, self);
-}
+CREATE_UNARY_FUNC(abs);
+CREATE_UNARY_FUNC(absolute);
+CREATE_UNARY_FUNC(asin);
+CREATE_UNARY_FUNC(arcsin);
+CREATE_UNARY_FUNC(asinh);
+CREATE_UNARY_FUNC(arcsinh);
+CREATE_UNARY_FUNC(atan);
+CREATE_UNARY_FUNC(arctan);
+CREATE_UNARY_FUNC(atanh);
+CREATE_UNARY_FUNC(arctanh);
+CREATE_UNARY_FUNC(ceil);
+CREATE_UNARY_FUNC(erf);
+CREATE_UNARY_FUNC(erfinv);
+CREATE_UNARY_FUNC(expm1);
+CREATE_UNARY_FUNC(log1p);
+CREATE_UNARY_FUNC(neg);
+CREATE_UNARY_FUNC(negative);
+CREATE_UNARY_FUNC(rad2deg);
+CREATE_UNARY_FUNC(sign);
+CREATE_UNARY_FUNC(sin);
+CREATE_UNARY_FUNC(sgn);
 
 template <typename scalar_t>
 void addmm_out_sparse_csr_native_cpu(const Tensor& sparse, const Tensor& dense, const Tensor& r, Scalar alpha, Scalar beta) {


### PR DESCRIPTION
1. `torch.abs` or `torch.absolute`
2. `torch.angle`
3. `torch.asin` or `torch.arcsin`
4. `torch.asinh` or `torch.arcsinh`
5. `torch.atan` or `torch.arctan`
6. `torch.atanh` or `torch.arctanh`
7. `torch.ceil` [ not for Long inputs ]
8. `torch.erf` / `torch.special.erf`
9. `torch.erfinv` / `torch.special.erfinv`
10. `torch.expm1` / `torch.special.expm1`
11. `torch.log1p`
12. `torch.neg` / `torch.negative`
13. `torch.positive`
14. `torch.rad2deg`
15. `torch.sign`
16. `torch.sgn`

**Doubts:**

* `conj`?
* `conj_physical` doesn't exist?
* `trunc`?
* `floor`?
* `frac`?
* `real` or `imag`: Is Sparse CSR implemented for complex types yet?
* What about ops like `torch.round`, which do not support long tensors?

**TODOs:**

1. Add more ops to the list.
2. Should the macros be separate? Example: `torch.positive` doesn't have `positive_outf`... Any other exceptions?