### PR TITLE
WIP: Support for Sparse Layout for `eye`

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2072,8 +2072,8 @@
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
-    SparseCPU, SparseCUDA: eye_sparse_m_out
-    SparseCsrCPU, SparseCsrCUDA: eye_sparse_csr_m_out
+    SparseCPU, SparseCUDA: eye_sparse_out
+    SparseCsrCPU, SparseCsrCUDA: eye_sparse_csr_out
 
 - func: flatten.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2065,11 +2065,15 @@
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
+    SparseCPU, SparseCUDA: eye_sparse_out
+    SparseCsrCPU, SparseCsrCUDA: eye_sparse_csr_out
 
 - func: eye.m_out(int n, int m, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
+    SparseCPU, SparseCUDA: eye_sparse_m_out
+    SparseCsrCPU, SparseCsrCUDA: eye_sparse_csr_m_out
 
 - func: flatten.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)
   variants: function, method

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -388,5 +388,21 @@ Tensor empty_like_sparse_csr(
   }
 }
 
+Tensor& eye_sparse_csr_out(int64_t n, Tensor& result) {
+  return eye_sparse_csr_out(n, n, result);
+}
+
+Tensor& eye_sparse_csr_out(int64_t n, int64_t m, Tensor& result) {
+  TORCH_INTERNAL_ASSERT(result.is_sparse_csr());
+
+  auto result_values = result.values();
+
+  // This call also ensures proper checks are done for the arguments
+  at::native::eye_out_cpu(n, m, result_values);
+
+  result.copy_(result_values.to_sparse_csr());
+  return result;
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -900,5 +900,30 @@ Tensor empty_like_sparse_coo(
   }
 }
 
+Tensor& eye_sparse_out(int64_t n, Tensor& result) {
+  return at::native::eye_sparse_out(n, n, result);
+}
+
+Tensor& eye_sparse_out(int64_t n, int64_t m, Tensor& result) {
+  TORCH_INTERNAL_ASSERT(result.is_sparse());
+
+  auto result_values = result.values();
+
+  // This call also ensures proper checks are done for the arguments
+  at::native::eye_out_cpu(n, m, result_values);
+
+  auto indices = at::native::nonzero(result_values, /*as_tuple=*/ true);
+
+  auto result = at::native::_sparse_coo_tensor_unsafe(
+    indices,
+    result_values,
+    result.sizes(),
+    result.layout(),
+    result_values.device()
+  );
+
+  return result;
+}
+
 } // namespace native
 } // namespace at


### PR DESCRIPTION
Current status:

Build failures:

```cpp
x86_64-conda-linux-gnu/bin/ld: /home/krshrimali/pytorch/build/lib/libtorch_cuda.so: undefined reference to `at::native::eye_sparse_out(long, at::Tensor&)'
x86_64-conda-linux-gnu/bin/ld: /home/krshrimali/pytorch/build/lib/libtorch_cuda.so: undefined reference to `at::native::eye_sparse_csr_out(long, long, at::Tensor&)'
x86_64-conda-linux-gnu/bin/ld: /home/krshrimali/pytorch/build/lib/libtorch_cuda.so: undefined reference to `at::native::eye_sparse_out(long, long, at::Tensor&)'
x86_64-conda-linux-gnu/bin/ld: /home/krshrimali/pytorch/build/lib/libtorch_cuda.so: undefined reference to `at::native::eye_sparse_csr_out(long, at::Tensor&)'
collect2: error: ld returned 1 exit status
```
cc: @IvanYashchuk for visibility  
